### PR TITLE
BUG FIX: Offset translation for scrolling the table view

### DIFF
--- a/SlideOverMap.xcodeproj/project.pbxproj
+++ b/SlideOverMap.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		24180CF41E48FEBF000A3DCF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24180CF21E48FEBF000A3DCF /* LaunchScreen.storyboard */; };
 		24180CFC1E48FF63000A3DCF /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24180CFB1E48FF63000A3DCF /* MapViewController.swift */; };
 		24180CFE1E48FFB1000A3DCF /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24180CFD1E48FFB1000A3DCF /* TableViewController.swift */; };
+		24FAB3E91E69E1DF00F59629 /* CGPoint+SlideyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FAB3E81E69E1DF00F59629 /* CGPoint+SlideyAdditions.swift */; };
 		2AA351DC1E68F2B300B491A9 /* SlideyController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACFCBA31E54FD8300F23F4F /* SlideyController.framework */; };
 		2AA351DD1E68F2B300B491A9 /* SlideyController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACFCBA31E54FD8300F23F4F /* SlideyController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2ACFCBA71E54FD8300F23F4F /* SlideyController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ACFCBA51E54FD8300F23F4F /* SlideyController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -57,6 +58,7 @@
 		24180CF51E48FEBF000A3DCF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24180CFB1E48FF63000A3DCF /* MapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		24180CFD1E48FFB1000A3DCF /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+		24FAB3E81E69E1DF00F59629 /* CGPoint+SlideyAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGPoint+SlideyAdditions.swift"; sourceTree = "<group>"; };
 		2ACFCBA31E54FD8300F23F4F /* SlideyController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SlideyController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2ACFCBA51E54FD8300F23F4F /* SlideyController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SlideyController.h; sourceTree = "<group>"; };
 		2ACFCBA61E54FD8300F23F4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				2ACFCBB91E54FFAC00F23F4F /* UIView+SlideyAdditions.swift */,
 				2ACFCBC21E55037900F23F4F /* UIViewController+SlideyAdditions.swift */,
+				24FAB3E81E69E1DF00F59629 /* CGPoint+SlideyAdditions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				2ACFCBC31E55037900F23F4F /* UIViewController+SlideyAdditions.swift in Sources */,
 				2ACFCBBF1E55009200F23F4F /* UIViewControllerProtocol.swift in Sources */,
 				2ACFCBC11E5500C100F23F4F /* FrontSlideable.swift in Sources */,
+				24FAB3E91E69E1DF00F59629 /* CGPoint+SlideyAdditions.swift in Sources */,
 				2ACFCBBC1E55003F00F23F4F /* BackSlideable.swift in Sources */,
 				2ACFCBBA1E54FFAC00F23F4F /* UIView+SlideyAdditions.swift in Sources */,
 				2ACFCBB81E54FFA500F23F4F /* SlideyController.swift in Sources */,

--- a/SlideyController/Extensions/CGPoint+SlideyAdditions.swift
+++ b/SlideyController/Extensions/CGPoint+SlideyAdditions.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright © 2017 Fish Hook LLC. All rights reserved.
+//
+
+import Foundation
+
+extension CGPoint {
+    
+    func offset(by initialTranslation: CGPoint) -> CGPoint
+    {
+        return CGPoint(x: x - initialTranslation.x, y: y - initialTranslation.y)
+    }
+}

--- a/SlideyController/View Controllers/SlideyController.swift
+++ b/SlideyController/View Controllers/SlideyController.swift
@@ -100,6 +100,7 @@ public class SlideyController: UIViewController {
     private var minTopConstraintConstant: CGFloat = 0.0
     private var maxTopConstraintConstant: CGFloat = 0.0
     private var initialTopConstraintConstant: CGFloat = 0.0
+    private var initialTranslation = CGPointZero
     
     private var slideyPosition = Position.Top {
         didSet {
@@ -134,22 +135,25 @@ extension SlideyController {
     
     @IBAction func gestureRecognized(_ sender: UIPanGestureRecognizer)
     {
-        if panGestureRecognizingState == .Inactive && slideableViewController?.overScrolling == true  {
-            panGestureRecognizingState = .Active
-        }
-        
         let translation = sender.translationInView(view)
         let velocity = sender.velocityInView(view)
+        
+        if panGestureRecognizingState == .Inactive && slideableViewController?.overScrolling == true  {
+            panGestureRecognizingState = .Active
+            initialTranslation = sender.translationInView(view)
+        }
+        
+        let offsetPoint = translation.offset(by: initialTranslation)
         
         if sender.state == .Began {
             initialTopConstraintConstant = slideyTopConstraint.constant
         }
         else if sender.state == .Ended && panGestureRecognizingState == .Active {
-            snapToPosition(calculatePosition(from: calculateTopConstraintConstant(from: translation.y), with: velocity.y))
+            snapToPosition(calculatePosition(from: calculateTopConstraintConstant(from: offsetPoint.y), with: velocity.y))
         }
         else if sender.state == .Changed && panGestureRecognizingState == .Active {
-            adjustConstraints(with: translation)
-            adjustDimmingView(with: translation)
+            adjustConstraints(with: offsetPoint)
+            adjustDimmingView(with: offsetPoint)
         }
     }
 }


### PR DESCRIPTION
BEFORE:

The front slideable controller is in the up position and scrolled all the way up on the table view (i.e. to the bottom of the table)

Lift finger up and stabilize. Table view scrolled to the bottom, map dimmed, etc.

3a. Swipe gesture down - this should be (and is) picked up by the table view until the table view scrolls all the way to the top…

3b. …whereupon the gesture recognizer takes it over and starts to slide the front view down.

HOWEVER, the constraint was being set continuously based 100% on gesture-translation.y, but without regard to the fact that much of that translation.y was taken up by the table view scrolling back to the top. This makes the front slideable view "jump" downward by however much translation.y was necessary to get the table view back to the top.
AFTER:

In gestureRecognized, get a “snapshot” of the tableViewScrollOffset. This equals however much translation.y it took to scroll the table view all the way back to the top.

Send that snapshot to adjustConstraints to use as an offset for setting the slideyTopConstraint.constant.

Ultimately, this means that the front slideable view won’t “jump” downwards if you scroll the table view with a gesture and continue that gesture, without interruption, to start sliding the front slideable view itself downwards.

This now mimics the behavior in Apple Maps.