### PR TITLE
REFACTOR: Do no re-offset map on sliding table view up

### DIFF
--- a/SlideyController/View Controllers/SlideyController.swift
+++ b/SlideyController/View Controllers/SlideyController.swift
@@ -101,7 +101,6 @@ public class SlideyController: UIViewController {
                 panGestureRecognizingState = .Inactive
                 
                 slideableViewController?.didSnapToTop()
-                backViewController?.bottomOffsetDidChange?(maxTopConstraintConstant)
                 backViewController?.isUserInteractionEnabled = false
                 
             case (_, .Top):


### PR DESCRIPTION
This leaves the re-offset and re-layout of the map view in place when you slide the front down, but removes it when you slide the front up. This is in response to:

“I've also noticed that raising the table view now just shrinks the available space for the map, causing it to rescale. Not a huge deal, but it does feel a little less like we're overlaying one view on the other because of this - and more like we're just letting one view squeeze into the other's available space.” in Ticket 699467.

I agree with the reasoning there.